### PR TITLE
UI Refactor: moved UI elements to .ui file + improved menu & overlay behaviorRefactor UI: moved menu and labels to .ui + cleaned logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -126,9 +126,10 @@ class MainWindow(QMainWindow):
         self.graphicsView.setAlignment(QtCore.Qt.AlignCenter)
         self.scene.setSceneRect(-400, -200, 800, 400)
 
-        self.scoreLabel = QtWidgets.QLabel("Score: 0", self.window)
-        self.levelLabel = QtWidgets.QLabel("Level: 1", self.window)
-        self.escLabel = QtWidgets.QLabel("\"esc\" to pause", self.window)
+        #take the labels define in main.ui
+        self.scoreLabel = self.window.findChild(QtWidgets.QLabel, "scoreLabel")
+        self.levelLabel = self.window.findChild(QtWidgets.QLabel, "levelLabel")
+        self.escLabel = self.window.findChild(QtWidgets.QLabel, "escLabel")
         self.scoreLabel.setAlignment(QtCore.Qt.AlignCenter)
         self.scoreLabel.setStyleSheet("color: white; font-size: 20px;")
         self.scoreLabel.setGeometry(350, 10, 100, 30)
@@ -137,7 +138,7 @@ class MainWindow(QMainWindow):
         self.levelLabel.setStyleSheet("color: cyan; font-size: 20px;")
         self.levelLabel.setGeometry(10, 10, 100, 30)
         
-        self.powerUpLabel = QtWidgets.QLabel("", self.window)
+        self.powerUpLabel = self.window.findChild(QtWidgets.QLabel, "powerUpLabel")
         self.powerUpLabel.setAlignment(QtCore.Qt.AlignCenter)
         self.powerUpLabel.setStyleSheet("color: yellow; font-size: 16px;")
         self.powerUpLabel.setGeometry(250, 350, 300, 30)
@@ -162,8 +163,17 @@ class MainWindow(QMainWindow):
 
         self.in_menu = True
         self.menu_selection = 0
-        self.start_button = None
-        self.quit_button = None
+
+        #take the labels define in main.ui
+        self.high_score_menu = self.window.findChild(QtWidgets.QLabel, "high_score_menu")
+        self.start_button = self.window.findChild(QtWidgets.QLabel, "start_button")
+        self.quit_button = self.window.findChild(QtWidgets.QLabel, "quit_button")
+        self.dummy_text = self.window.findChild(QtWidgets.QLabel, "dummy_text")
+
+        #make the labels clickable
+        self.start_button.mousePressEvent = self.start_button_clicked
+        self.quit_button.mousePressEvent = self.quit_button_clicked
+
         self.show_start_menu()
 
         self.window.show()
@@ -503,8 +513,6 @@ class MainWindow(QMainWindow):
 
         self.in_menu = True
         self.menu_selection = 0
-        self.start_button = None
-        self.quit_button = None
 
         self.show_start_menu()
         self.update_score()
@@ -513,34 +521,14 @@ class MainWindow(QMainWindow):
     def show_start_menu(self):
         self.in_menu = True
         self.scene.clear()
-        
-        # Show high score in menu
-        self.high_score_menu = QtWidgets.QLabel(f"High Score: {self.high_score}", self.window)
-        self.high_score_menu.setAlignment(QtCore.Qt.AlignCenter)
-        self.high_score_menu.setStyleSheet("color: gold; font-size: 24px; font-weight: bold;")
-        self.high_score_menu.setGeometry(250, 50, 300, 50)
+
+        self.high_score_menu.setText(f"High Score: {self.high_score}")
         self.high_score_menu.show()
-
-        self.start_button = QtWidgets.QLabel("START", self.window)
-        self.start_button.setAlignment(QtCore.Qt.AlignCenter)
-        self.start_button.setStyleSheet("color: white; font-size: 30px;")
-        self.start_button.setGeometry(350, 150, 100, 50)
         self.start_button.show()
-        self.start_button.mousePressEvent = self.start_button_clicked
-
-        self.quit_button = QtWidgets.QLabel("QUIT", self.window)
-        self.quit_button.setAlignment(QtCore.Qt.AlignCenter)
-        self.quit_button.setStyleSheet("color: white; font-size: 30px;")
-        self.quit_button.setGeometry(350, 250, 100, 50)
         self.quit_button.show()
-        self.quit_button.mousePressEvent = self.quit_button_clicked
-
-        self.dummy_text = QtWidgets.QLabel("Use Keyboard Keys or Mouse To Navigate!", self.window)
-        self.dummy_text.setAlignment(QtCore.Qt.AlignCenter)
-        self.dummy_text.setStyleSheet("color: green; font-size: 14px;")
-        self.dummy_text.setGeometry(250, 350, 300, 50)
         self.dummy_text.show()
 
+        self.menu_selection = 0
         self.update_menu_selection()
         self.window.update()
 
@@ -559,10 +547,10 @@ class MainWindow(QMainWindow):
         QApplication.quit()
 
     def start_game(self):
-        self.start_button.deleteLater()
-        self.quit_button.deleteLater()
-        self.dummy_text.deleteLater()
-        self.high_score_menu.deleteLater()
+        self.start_button.hide()
+        self.quit_button.hide()
+        self.dummy_text.hide()
+        self.high_score_menu.hide()
         self.in_menu = False
         self.snake = Snake()
         self.level = 1  # Reset level

--- a/main.py
+++ b/main.py
@@ -130,18 +130,7 @@ class MainWindow(QMainWindow):
         self.scoreLabel = self.window.findChild(QtWidgets.QLabel, "scoreLabel")
         self.levelLabel = self.window.findChild(QtWidgets.QLabel, "levelLabel")
         self.escLabel = self.window.findChild(QtWidgets.QLabel, "escLabel")
-        self.scoreLabel.setAlignment(QtCore.Qt.AlignCenter)
-        self.scoreLabel.setStyleSheet("color: white; font-size: 20px;")
-        self.scoreLabel.setGeometry(350, 10, 100, 30)
-        
-        self.levelLabel.setAlignment(QtCore.Qt.AlignCenter)
-        self.levelLabel.setStyleSheet("color: cyan; font-size: 20px;")
-        self.levelLabel.setGeometry(10, 10, 100, 30)
-        
         self.powerUpLabel = self.window.findChild(QtWidgets.QLabel, "powerUpLabel")
-        self.powerUpLabel.setAlignment(QtCore.Qt.AlignCenter)
-        self.powerUpLabel.setStyleSheet("color: yellow; font-size: 16px;")
-        self.powerUpLabel.setGeometry(250, 350, 300, 30)
         self.powerUpLabel.hide()
 
         self.timer = QtCore.QTimer()
@@ -166,13 +155,14 @@ class MainWindow(QMainWindow):
 
         #take the labels define in main.ui
         self.high_score_menu = self.window.findChild(QtWidgets.QLabel, "high_score_menu")
-        self.start_button = self.window.findChild(QtWidgets.QLabel, "start_button")
-        self.quit_button = self.window.findChild(QtWidgets.QLabel, "quit_button")
+        self.start_button = self.window.findChild(QtWidgets.QPushButton, "start_button")
+        self.quit_button = self.window.findChild(QtWidgets.QPushButton, "quit_button")
         self.dummy_text = self.window.findChild(QtWidgets.QLabel, "dummy_text")
 
-        #make the labels clickable
-        self.start_button.mousePressEvent = self.start_button_clicked
-        self.quit_button.mousePressEvent = self.quit_button_clicked
+        self.start_button.clicked.connect(self.start_button_clicked)
+        self.quit_button.clicked.connect(self.quit_button_clicked)
+
+
 
         self.show_start_menu()
 
@@ -512,8 +502,6 @@ class MainWindow(QMainWindow):
         self.level = 1  # Reset level
 
         self.in_menu = True
-        self.menu_selection = 0
-
         self.show_start_menu()
         self.update_score()
         self.update_level()
@@ -540,11 +528,11 @@ class MainWindow(QMainWindow):
             self.start_button.setStyleSheet("color: white; font-size: 30px;")
             self.quit_button.setStyleSheet("color: yellow; font-size: 30px;")
 
-    def start_button_clicked(self, event):
+    def start_button_clicked(self):
         self.start_game()
 
-    def quit_button_clicked(self, event):
-        QApplication.quit()
+    def quit_button_clicked(self):
+        QtWidgets.QApplication.quit()
 
     def start_game(self):
         self.start_button.hide()

--- a/main.ui
+++ b/main.ui
@@ -32,39 +32,199 @@
    <string>QtSnake</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QGridLayout" name="gridLayout_2">
-    <property name="leftMargin">
-     <number>0</number>
+   <widget class="QGraphicsView" name="graphicsView">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>0</y>
+      <width>791</width>
+      <height>391</height>
+     </rect>
     </property>
-    <property name="topMargin">
-     <number>0</number>
+    <property name="autoFillBackground">
+     <bool>false</bool>
     </property>
-    <property name="rightMargin">
-     <number>0</number>
+    <property name="styleSheet">
+     <string notr="true">background-color: black; </string>
     </property>
-    <property name="bottomMargin">
-     <number>0</number>
+    <property name="backgroundBrush">
+     <brush brushstyle="NoBrush">
+      <color alpha="255">
+       <red>0</red>
+       <green>0</green>
+       <blue>0</blue>
+      </color>
+     </brush>
     </property>
-    <property name="spacing">
-     <number>0</number>
+   </widget>
+   <widget class="QLabel" name="scoreLabel">
+    <property name="geometry">
+     <rect>
+      <x>370</x>
+      <y>20</y>
+      <width>49</width>
+      <height>16</height>
+     </rect>
     </property>
-    <item row="0" column="0">
-     <widget class="QGraphicsView" name="graphicsView">
-      <property name="autoFillBackground">
-       <bool>false</bool>
-      </property>
-      <property name="backgroundBrush">
-       <brush brushstyle="NoBrush">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </property>
-     </widget>
-    </item>
-   </layout>
+    <property name="styleSheet">
+     <string notr="true">color: white;</string>
+    </property>
+    <property name="text">
+     <string>Score: 0</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignmentFlag::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="levelLabel">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>20</y>
+      <width>49</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: rgb(0, 255, 255);</string>
+    </property>
+    <property name="text">
+     <string>Level: 1</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="escLabel">
+    <property name="geometry">
+     <rect>
+      <x>690</x>
+      <y>10</y>
+      <width>91</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: rgb(0, 255, 127)</string>
+    </property>
+    <property name="text">
+     <string>&quot;esc&quot; to pause</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignmentFlag::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="powerUpLabel">
+    <property name="geometry">
+     <rect>
+      <x>370</x>
+      <y>350</y>
+      <width>49</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: rgb(255, 255, 0)</string>
+    </property>
+    <property name="text">
+     <string>TextLabel</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignmentFlag::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="high_score_menu">
+    <property name="geometry">
+     <rect>
+      <x>340</x>
+      <y>40</y>
+      <width>131</width>
+      <height>31</height>
+     </rect>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: rgb(255, 255, 0);
+font: 600 14pt &quot;Segoe UI&quot;;</string>
+    </property>
+    <property name="text">
+     <string>High Score: 0</string>
+    </property>
+    <property name="textFormat">
+     <enum>Qt::TextFormat::RichText</enum>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignmentFlag::AlignCenter</set>
+    </property>
+    <property name="margin">
+     <number>-1</number>
+    </property>
+   </widget>
+   <widget class="QLabel" name="start_button">
+    <property name="geometry">
+     <rect>
+      <x>350</x>
+      <y>80</y>
+      <width>101</width>
+      <height>41</height>
+     </rect>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: white</string>
+    </property>
+    <property name="text">
+     <string>START</string>
+    </property>
+    <property name="textFormat">
+     <enum>Qt::TextFormat::AutoText</enum>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignmentFlag::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="quit_button">
+    <property name="geometry">
+     <rect>
+      <x>320</x>
+      <y>160</y>
+      <width>161</width>
+      <height>81</height>
+     </rect>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: white</string>
+    </property>
+    <property name="text">
+     <string>QUIT</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignmentFlag::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="dummy_text">
+    <property name="geometry">
+     <rect>
+      <x>200</x>
+      <y>370</y>
+      <width>431</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: rgb(0, 255, 127)</string>
+    </property>
+    <property name="text">
+     <string>Use Keyboard Keys or Mouse To Navigate!</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignmentFlag::AlignCenter</set>
+    </property>
+   </widget>
+   <zorder>graphicsView</zorder>
+   <zorder>scoreLabel</zorder>
+   <zorder>escLabel</zorder>
+   <zorder>levelLabel</zorder>
+   <zorder>powerUpLabel</zorder>
+   <zorder>high_score_menu</zorder>
+   <zorder>start_button</zorder>
+   <zorder>quit_button</zorder>
+   <zorder>dummy_text</zorder>
   </widget>
  </widget>
  <resources/>

--- a/main.ui
+++ b/main.ui
@@ -114,10 +114,10 @@
    <widget class="QLabel" name="powerUpLabel">
     <property name="geometry">
      <rect>
-      <x>370</x>
+      <x>280</x>
       <y>350</y>
-      <width>49</width>
-      <height>16</height>
+      <width>271</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="styleSheet">
@@ -156,47 +156,6 @@ font: 600 14pt &quot;Segoe UI&quot;;</string>
      <number>-1</number>
     </property>
    </widget>
-   <widget class="QLabel" name="start_button">
-    <property name="geometry">
-     <rect>
-      <x>350</x>
-      <y>80</y>
-      <width>101</width>
-      <height>41</height>
-     </rect>
-    </property>
-    <property name="styleSheet">
-     <string notr="true">color: white</string>
-    </property>
-    <property name="text">
-     <string>START</string>
-    </property>
-    <property name="textFormat">
-     <enum>Qt::TextFormat::AutoText</enum>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignmentFlag::AlignCenter</set>
-    </property>
-   </widget>
-   <widget class="QLabel" name="quit_button">
-    <property name="geometry">
-     <rect>
-      <x>320</x>
-      <y>160</y>
-      <width>161</width>
-      <height>81</height>
-     </rect>
-    </property>
-    <property name="styleSheet">
-     <string notr="true">color: white</string>
-    </property>
-    <property name="text">
-     <string>QUIT</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignmentFlag::AlignCenter</set>
-    </property>
-   </widget>
    <widget class="QLabel" name="dummy_text">
     <property name="geometry">
      <rect>
@@ -216,15 +175,49 @@ font: 600 14pt &quot;Segoe UI&quot;;</string>
      <set>Qt::AlignmentFlag::AlignCenter</set>
     </property>
    </widget>
+   <widget class="QPushButton" name="start_button">
+    <property name="geometry">
+     <rect>
+      <x>310</x>
+      <y>80</y>
+      <width>191</width>
+      <height>81</height>
+     </rect>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: rgb(255, 255, 255);
+font: 18pt &quot;Segoe UI&quot;;</string>
+    </property>
+    <property name="text">
+     <string>START</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="quit_button">
+    <property name="geometry">
+     <rect>
+      <x>310</x>
+      <y>200</y>
+      <width>191</width>
+      <height>81</height>
+     </rect>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: rgb(255, 255, 255);
+font: 18pt &quot;Segoe UI&quot;;</string>
+    </property>
+    <property name="text">
+     <string>QUIT</string>
+    </property>
+   </widget>
    <zorder>graphicsView</zorder>
    <zorder>scoreLabel</zorder>
    <zorder>escLabel</zorder>
    <zorder>levelLabel</zorder>
    <zorder>powerUpLabel</zorder>
    <zorder>high_score_menu</zorder>
+   <zorder>dummy_text</zorder>
    <zorder>start_button</zorder>
    <zorder>quit_button</zorder>
-   <zorder>dummy_text</zorder>
   </widget>
  </widget>
  <resources/>


### PR DESCRIPTION
Hi,
This pull request moves all UI-related elements (score label, level label, ESC hint, power-up label, menu labels) from main.py into the main.ui file.
This improves:
- separation between logic and UI
- readability
- maintainability
- easier UI changes through Qt Designer
- prevents duplicate widgets being created/destroyed each cycle

Let me know if you want any adjustments!